### PR TITLE
Fixed querying the version from the cache using the right stream type

### DIFF
--- a/src/init
+++ b/src/init
@@ -123,7 +123,7 @@ else
       do
         # looking for baked versions
         if [[ ! -z "$BACKBONE_ACTIVE_VERSIONS_CONFIG" ]]; then
-          coreVersionValue=$(cat $BACKBONE_ACTIVE_VERSIONS_CONFIG | jq -r ".data.\"${coreDirectory[$coreKind]}/$core\".$autoAssignType.version")
+          coreVersionValue=$(cat $BACKBONE_ACTIVE_VERSIONS_CONFIG | jq -r ".data.\"${coreDirectory[$coreKind]}/$core\".$bashVersionType.version")
           if [[ $coreVersionValue == "null" ]]; then
             coreVersionValue=""
           fi


### PR DESCRIPTION
This pull request fixes an issue related when querying the version from a specific module from the cache which would always use auto assign type instead of the base version type.