### PR TITLE
Making sure unsupported unicode characters are ignored

### DIFF
--- a/src/bin/bsettings
+++ b/src/bin/bsettings
@@ -210,7 +210,7 @@ class BackboneSettingsDialog(QtWidgets.QDialog):
         return list(
             filter(lambda x: len(x), map(str.strip, subprocess.check_output(
                 command
-            ).decode('utf-8').replace('\r', '').split('\n')))
+            ).decode('utf-8', 'ignore').replace('\r', '').split('\n')))
         )
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull fixes an issue happening when decoding an output of a subprocess used to query the list of drives.