### PR TITLE
Added support for blocksize

### DIFF
--- a/src/bin/cres
+++ b/src/bin/cres
@@ -37,17 +37,19 @@ function cachedResource()
       >&2 echo "Waiting for unpacking (started by another process): $resourceLocation"
       while [ -d "$resourceUnpackingDirectory" ]
       do
-	sleep 2.0
+	sleep 20.0
 	if [ -f $resourceUnpackingLock ]; then
-	  if test $(find "$resourceUnpackingLock" -mmin +1)
+	  if test $(find "$resourceUnpackingLock" -mmin +2)
 	  then
 	      >&2 echo "Previous unpacking failed, starting over..."
 	      runExtraction=1
 	      break
 	  fi
 	else
-	  >&2 echo "Previous unpacking is corrupted, starting over..."
-	  runExtraction=1
+	  if [[ -d "$resourceUnpackingDirectory" ]]; then
+	    >&2 echo "Previous unpacking is corrupted, starting over..."
+	    runExtraction=1
+	  fi
 	  break
 	fi
       done

--- a/src/bin/ures
+++ b/src/bin/ures
@@ -44,8 +44,14 @@ function unpackResource()
   local copiedPackageResource=""
   if [ -f $resourceChecksum ]; then
     copiedPackageResource="$cacheUnpackingDirectory/$(basename $resourcePackage)"
-    command cp $resourcePackage $copiedPackageResource &
-    pid=$!
+    if [[ -z "$BACKBONE_URES_BLOCK_SIZE" ]]; then
+      command cp $resourcePackage $copiedPackageResource &
+      pid=$!
+    else
+      command dd if=$resourcePackage of=$copiedPackageResource bs=$BACKBONE_URES_BLOCK_SIZE status=none &
+      pid=$!
+    fi
+
     local totalLabel=$(echo $resourceSize | numfmt --to=iec --format='%.2fB')
     local currentProgressInterval="0"
     local currentProgressTotal="0"


### PR DESCRIPTION
This pull request adds support for specifying the block size during the copy of resources. Also, it fixes a small bug related with detecting corrupted extractions.