### PR TITLE
Trying multiple times to rename a busy directory

### DIFF
--- a/src/bin/ures
+++ b/src/bin/ures
@@ -129,8 +129,28 @@ function unpackResource()
   command rm $cacheUnpackingLock
   command rm $extractionCopyChecksum
 
-  # when unpacking is done we rename it to be available atomically
-  command mv "$cacheUnpackingDirectory" "$targetCacheLocation"
+  # when extracting lot of files it could happen that a process may start
+  # scanning the contents of the directory. Therefore, not letting to rename
+  # it. Because of that we are giving 5 minutes of attempts to rename the
+  # directory.
+  maxAttempts=20
+  for i in $(seq 1 $maxAttempts)
+  do
+    # when unpacking is done we rename it to be available atomically
+    command mv "$cacheUnpackingDirectory" "$targetCacheLocation" >& /dev/null
+    result=$?
+
+    if [[ $result -eq 0 ]]
+    then
+      break
+    else
+      sleep 15
+    fi
+  done
+
+  if [[ -d "$cacheUnpackingDirectory" ]]; then
+    >&2 echo "Failed to rename $cacheUnpackingDirectory to $targetCacheLocation"
+  fi
 
   echo $targetCacheLocation
 }


### PR DESCRIPTION
On windows a process can be scanning the directory used for the extraction. When that happens there is a race condition where the directory may not be able to get renamed because there is a child file being used by another process. Therefore, to address that issue this implementation tries multiple times to rename the directory for up to 5 minutes til it gives up. 